### PR TITLE
style:change title

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -120,6 +120,18 @@ button:hover {
     animation: spin 2s linear infinite;
 }
 
+span.title {
+	font-size: 2.5rem;
+	font-weight: 400;
+	margin: 0 0 20px;
+	width: 10px;
+	height: 10px;
+	background-color: blueviolet;
+	border-radius: 50%;
+	margin: 0 5px;
+	animation: bounce 0.5s ease infinite alternate;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -4,23 +4,7 @@
 // 	);
 // };
 
-/*
-Tips: カッコの種類と英語名
-「小・中・大」は一部でしか通じない呼び方。
-英名か、「丸括弧・波括弧・角括弧」と呼んだ方がまだ誤解がない。
-() = parentheses （丸括弧。「小かっこ」と呼ばれることもある）
-{} = (curly) braces　（波括弧。「中かっこ」と呼ばれることもある）
-[] = (square) brackets　（角括弧。「大かっこ」と呼ばれることもある）
-*/
-
-// returnと中括弧{}を省略して以下のように書くこともできる
-// const Title = () => (
-// 	<h1>React World
-// 		<span>Weather</span>
-// 	</h1>
-// )
-
-//returnの中の要素が1個だけの場合、()も全て省略して以下のように書くこともできる
-const Title = () => <h1>React World <span>Weather</span></h1>;
+// returnと中括弧{}の省略や、更に()も全て省略し以下のように書くこともできる
+const Title = () => <h1>React World Weather <span className="title">with TypeScript</span></h1>;
 
 export default Title;


### PR DESCRIPTION
タイトルにwith TypeScriptの文言追加とスタイルシートの適用

都市名の入力エラーで検索に失敗した場合、検索中のLoading画面と以前の入力値が残るのを「仕様」として残す方針で決定。
初期画面に戻した方がより望ましいのか、第三者の意見が欲しいところ。